### PR TITLE
Add filtering by sector and employee type

### DIFF
--- a/src/main/java/com/tatilsorgulama/api/controller/HolidayController.java
+++ b/src/main/java/com/tatilsorgulama/api/controller/HolidayController.java
@@ -31,11 +31,23 @@ public class HolidayController {
     public ResponseEntity<List<Holiday>> queryHolidays(
             @RequestParam Integer countryId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
-        
+
         List<Holiday> holidays = holidayRepository.findByCountry_CountryIdAndHolidayDate(countryId, date);
         if (holidays.isEmpty()) {
             return ResponseEntity.noContent().build(); // Tatil bulunamadıysa 204 No Content döner
         }
+        return ResponseEntity.ok(holidays);
+    }
+
+    // Yeni: /api/holidays/filter?countryId=1&sectorType=Public&employeeTypeId=2
+    // Seçilen ülke, sektör ve çalışan tipine uygun tatilleri listeler
+    @GetMapping("/filter")
+    public ResponseEntity<List<Holiday>> filterHolidays(
+            @RequestParam Integer countryId,
+            @RequestParam String sectorType,
+            @RequestParam Integer employeeTypeId) {
+        List<Holiday> holidays = holidayRepository
+                .findByCountryAndSectorAndEmployeeType(countryId, sectorType, employeeTypeId);
         return ResponseEntity.ok(holidays);
     }
 

--- a/src/main/java/com/tatilsorgulama/api/repository/HolidayRepository.java
+++ b/src/main/java/com/tatilsorgulama/api/repository/HolidayRepository.java
@@ -23,4 +23,19 @@ public interface HolidayRepository extends JpaRepository<Holiday, Integer> {
      * Sadece ülkeye göre arama yapmak için bir başka örnek metot.
      */
     List<Holiday> findByCountry_CountryId(Integer countryId);
+
+    /**
+     * Finds holidays for employees matching sector and employee type in a given country.
+     * Uses Employee entity to filter relevant holidays by country, sector and employee type.
+     */
+    @org.springframework.data.jpa.repository.Query(
+            "select distinct h from Holiday h " +
+                    "join h.country c " +
+                    "join Employee e on e.country = c " +
+                    "where c.countryId = :countryId " +
+                    "and e.sectorType = :sectorType " +
+                    "and e.employeeType.employeeTypeId = :employeeTypeId")
+    java.util.List<Holiday> findByCountryAndSectorAndEmployeeType(Integer countryId,
+                                                                  String sectorType,
+                                                                  Integer employeeTypeId);
 }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -91,13 +91,18 @@ function createCalendar() {
     document.getElementById('viewSelect').addEventListener('change', () => {
         calendar.changeView(document.getElementById('viewSelect').value);
     });
+    ['country', 'sector', 'employeeType'].forEach(id => {
+        document.getElementById(id).addEventListener('change', () => calendar.refetchEvents());
+    });
     return calendar;
 }
 
 async function fetchEvents(fetchInfo, successCallback, failureCallback) {
     try {
         const countryId = document.getElementById('country').value;
-        const res = await fetch(`/api/holidays?countryId=${countryId}`);
+        const sector = document.getElementById('sector').value;
+        const employeeTypeId = document.getElementById('employeeType').value;
+        const res = await fetch(`/api/holidays/filter?countryId=${countryId}&sectorType=${encodeURIComponent(sector)}&employeeTypeId=${employeeTypeId}`);
         const holidays = await res.json();
         const events = holidays.map(h => ({
             title: h.holidayName,


### PR DESCRIPTION
## Summary
- introduce `findByCountryAndSectorAndEmployeeType` query to `HolidayRepository`
- expose `/api/holidays/filter` endpoint in `HolidayController`
- update calendar frontend to send filter parameters and refresh on change

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686645fccdc8832eaba604ff013633e5