### PR TITLE
Implement sector-based holiday range query

### DIFF
--- a/src/main/java/com/tatilsorgulama/api/controller/HolidayController.java
+++ b/src/main/java/com/tatilsorgulama/api/controller/HolidayController.java
@@ -65,6 +65,22 @@ public class HolidayController {
         return ResponseEntity.ok(holidays);
     }
 
+    /**
+     * Lists holidays between two dates for a given country and sector.
+     * Example: /api/holidays/range?countryId=1&sectorType=Public&start=2024-01-01&end=2024-12-31
+     */
+    @GetMapping("/range")
+    public ResponseEntity<List<Holiday>> getHolidaysInRange(
+            @RequestParam Integer countryId,
+            @RequestParam String sectorType,
+            @RequestParam("start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam("end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+
+        List<Holiday> holidays = holidayRepository
+                .findByCountrySectorAndDateBetween(countryId, sectorType, startDate, endDate);
+        return ResponseEntity.ok(holidays);
+    }
+
     // Örnek: POST isteği ile /api/holidays adresine JSON formatında yeni tatil bilgisi göndermek
     @PostMapping
     public ResponseEntity<Holiday> createHoliday(@RequestBody Holiday newHoliday) {

--- a/src/main/java/com/tatilsorgulama/api/repository/HolidayRepository.java
+++ b/src/main/java/com/tatilsorgulama/api/repository/HolidayRepository.java
@@ -39,4 +39,19 @@ public interface HolidayRepository extends JpaRepository<Holiday, Integer> {
             "where c.countryId = :countryId " +
             "and e.sectorType = :sectorType")
     List<Holiday> findByCountryAndSector(Integer countryId, String sectorType);
+
+    /**
+     * Lists holidays in a given country and sector between two dates.
+     */
+    @Query(
+            "select distinct h from Holiday h " +
+            "join h.country c " +
+            "join Employee e on e.country = c " +
+            "where c.countryId = :countryId " +
+            "and e.sectorType = :sectorType " +
+            "and h.holidayDate between :startDate and :endDate")
+    List<Holiday> findByCountrySectorAndDateBetween(Integer countryId,
+                                                   String sectorType,
+                                                   LocalDate startDate,
+                                                   LocalDate endDate);
 }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -27,10 +27,17 @@
         <option value="dayGridMonth">Aylık</option>
         <option value="multiMonthYear">Yıllık</option>
     </select>
+
+    <label for="startDate">Başlangıç:</label>
+    <input type="date" id="startDate">
+    <label for="endDate">Bitiş:</label>
+    <input type="date" id="endDate">
+    <button id="rangeBtn">Aralığı Hesapla</button>
 </div>
 
 <div id="holidaySummary"></div>
 <div id="calendar"></div>
+<div id="rangeResult"></div>
 <div id="holidayDetails"></div>
 
 <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
@@ -107,6 +114,8 @@ function setupEventListeners() {
             calendar.changeView(event.target.value);
         }
     });
+
+    document.getElementById('rangeBtn').addEventListener('click', calculateRange);
 }
 
 async function fetchEvents(fetchInfo, successCallback, failureCallback) {
@@ -127,7 +136,7 @@ async function fetchEvents(fetchInfo, successCallback, failureCallback) {
         const holidays = await res.json();
         
         const events = holidays.map(h => ({
-            title: h.holidayName,
+            title: `${h.holidayName} (${h.appliesToSector})`,
             start: h.holidayDate,
             extendedProps: h
         }));
@@ -164,6 +173,28 @@ function showDetails(info) {
         <p><strong>Geçerli Sektör:</strong> ${h.appliesToSector}</p>
     `;
     document.getElementById('holidayDetails').innerHTML = details;
+}
+
+async function calculateRange() {
+    const countryId = document.getElementById('country').value;
+    const sector = document.getElementById('sector').value;
+    const start = document.getElementById('startDate').value;
+    const end = document.getElementById('endDate').value;
+
+    if (!countryId || !sector || !start || !end) {
+        document.getElementById('rangeResult').textContent = 'Lütfen tüm alanları doldurun.';
+        return;
+    }
+
+    try {
+        const res = await fetch(`/api/holidays/range?countryId=${countryId}&sectorType=${encodeURIComponent(sector)}&start=${start}&end=${end}`);
+        if (!res.ok) throw new Error('Tatiller getirilemedi.');
+        const holidays = await res.json();
+        document.getElementById('rangeResult').textContent = `Toplam ${holidays.length} tatil bulundu.`;
+    } catch (e) {
+        console.error(e);
+        document.getElementById('rangeResult').textContent = 'Hata oluştu.';
+    }
 }
 
 async function init() {


### PR DESCRIPTION
## Summary
- support querying holidays within a date range for a country & sector
- expose new `/range` endpoint
- enhance UI to show sector on each holiday and allow date range queries

## Testing
- `./mvnw -q test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6867975bbe48832ea34c1883fafd460e