### PR TITLE
Enhance holiday UI with language and range filters

### DIFF
--- a/src/main/java/com/tatilsorgulama/api/controller/HolidayController.java
+++ b/src/main/java/com/tatilsorgulama/api/controller/HolidayController.java
@@ -2,6 +2,8 @@ package com.tatilsorgulama.api.controller;
 
 import com.tatilsorgulama.api.entity.Holiday;
 import com.tatilsorgulama.api.repository.HolidayRepository;
+import com.tatilsorgulama.api.dto.HolidayDescDto;
+import com.tatilsorgulama.api.repository.HolidayDescriptionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +18,7 @@ import java.util.List;
 public class HolidayController {
 
     private final HolidayRepository holidayRepository;
+    private final HolidayDescriptionRepository descriptionRepository;
 
     // Lists all holidays for a given country
     @GetMapping
@@ -60,6 +63,29 @@ public class HolidayController {
         List<Holiday> holidays = holidayRepository
                 .findByCountryTargetGroupAndDateBetween(countryId, targetGroup, startDate, endDate);
         return ResponseEntity.ok(holidays);
+    }
+
+    // Range query with holiday type and target group
+    @GetMapping("/range-filtered")
+    public ResponseEntity<List<Holiday>> getHolidaysInRangeFiltered(
+            @RequestParam Integer countryId,
+            @RequestParam String holidayType,
+            @RequestParam String targetGroup,
+            @RequestParam("start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam("end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+
+        List<Holiday> holidays = holidayRepository
+                .findByCountryTypeGroupAndDateBetween(countryId, holidayType, targetGroup, startDate, endDate);
+        return ResponseEntity.ok(holidays);
+    }
+
+    // Returns holiday descriptions for a country and language
+    @GetMapping("/descriptions")
+    public ResponseEntity<List<HolidayDescDto>> getHolidayDescriptions(
+            @RequestParam Integer countryId,
+            @RequestParam String language) {
+        List<HolidayDescDto> list = descriptionRepository.findByCountryAndLanguage(countryId, language);
+        return ResponseEntity.ok(list);
     }
 
     // Örnek: POST isteği ile /api/holidays adresine JSON formatında yeni tatil bilgisi göndermek

--- a/src/main/java/com/tatilsorgulama/api/controller/HolidayTypeController.java
+++ b/src/main/java/com/tatilsorgulama/api/controller/HolidayTypeController.java
@@ -1,0 +1,23 @@
+package com.tatilsorgulama.api.controller;
+
+import com.tatilsorgulama.api.entity.HolidayType;
+import com.tatilsorgulama.api.repository.HolidayTypeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/holiday-types")
+@RequiredArgsConstructor
+public class HolidayTypeController {
+
+    private final HolidayTypeRepository repository;
+
+    @GetMapping
+    public List<HolidayType> getAll() {
+        return repository.findAll();
+    }
+}

--- a/src/main/java/com/tatilsorgulama/api/controller/TargetGroupController.java
+++ b/src/main/java/com/tatilsorgulama/api/controller/TargetGroupController.java
@@ -1,0 +1,23 @@
+package com.tatilsorgulama.api.controller;
+
+import com.tatilsorgulama.api.entity.TargetGroup;
+import com.tatilsorgulama.api.repository.TargetGroupRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/target-groups")
+@RequiredArgsConstructor
+public class TargetGroupController {
+
+    private final TargetGroupRepository repository;
+
+    @GetMapping
+    public List<TargetGroup> getAll() {
+        return repository.findAll();
+    }
+}

--- a/src/main/java/com/tatilsorgulama/api/dto/HolidayDescDto.java
+++ b/src/main/java/com/tatilsorgulama/api/dto/HolidayDescDto.java
@@ -1,0 +1,5 @@
+package com.tatilsorgulama.api.dto;
+
+import java.time.LocalDate;
+
+public record HolidayDescDto(LocalDate startDate, LocalDate endDate, String name, String description) {}

--- a/src/main/java/com/tatilsorgulama/api/repository/HolidayDescriptionRepository.java
+++ b/src/main/java/com/tatilsorgulama/api/repository/HolidayDescriptionRepository.java
@@ -3,7 +3,18 @@ package com.tatilsorgulama.api.repository;
 import com.tatilsorgulama.api.entity.HolidayDescription;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import com.tatilsorgulama.api.dto.HolidayDescDto;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 @Repository
+
 public interface HolidayDescriptionRepository extends JpaRepository<HolidayDescription, Integer> {
+
+    @Query("select new com.tatilsorgulama.api.dto.HolidayDescDto(h.startDate, h.endDate, hd.name, hd.description) " +
+           "from HolidayDescription hd join hd.holiday h " +
+           "where h.country.id = :countryId and hd.languageCode = :lang " +
+           "order by h.startDate")
+    List<HolidayDescDto> findByCountryAndLanguage(@Param("countryId") Integer countryId,
+                                                  @Param("lang") String languageCode);
 }

--- a/src/main/java/com/tatilsorgulama/api/repository/HolidayRepository.java
+++ b/src/main/java/com/tatilsorgulama/api/repository/HolidayRepository.java
@@ -23,4 +23,15 @@ public interface HolidayRepository extends JpaRepository<Holiday, Integer> {
                                                          String groupCode,
                                                          LocalDate startDate,
                                                          LocalDate endDate);
+
+    @Query("select distinct h from Holiday h join h.targetGroups tg " +
+            "where h.country.id = :countryId " +
+            "and tg.code = :groupCode " +
+            "and h.holidayType.code = :typeCode " +
+            "and h.startDate between :startDate and :endDate")
+    List<Holiday> findByCountryTypeGroupAndDateBetween(Integer countryId,
+                                                       String typeCode,
+                                                       String groupCode,
+                                                       LocalDate startDate,
+                                                       LocalDate endDate);
 }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="tr">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <title>Tatil Takvimi</title>
@@ -63,28 +63,37 @@
 </head>
 <body>
 <div id="controls">
-    <div style="margin-bottom: 20px;">
-        <label for="country">Ülke:</label>
+    <div style="margin-bottom: 20px; display:flex; gap:10px; align-items:center;">
+        <label for="country" id="lblCountry">Country:</label>
         <select id="country"></select>
 
-        <label for="viewSelect">Görünüm:</label>
+        <label for="viewSelect" id="lblView">View:</label>
         <select id="viewSelect">
-            <option value="dayGridMonth">Aylık</option>
-            <option value="multiMonthYear">Yıllık</option>
+            <option value="dayGridMonth" id="optMonth">Monthly</option>
+            <option value="multiMonthYear" id="optYear">Yearly</option>
+        </select>
+
+        <label for="lang" id="lblLang">Language:</label>
+        <select id="lang">
+            <option value="en">EN</option>
+            <option value="fr">FR</option>
         </select>
     </div>
 
     <div id="calendar" style="margin-bottom: 20px;"></div>
 
-    <div style="margin-bottom: 20px;">
-        <label for="sector">Sektör Tipi:</label>
+    <div style="margin-bottom: 20px; display:flex; gap:10px; align-items:center; flex-wrap:wrap;">
+        <label for="type" id="lblType">Type:</label>
+        <select id="type"></select>
+
+        <label for="sector" id="lblTarget">Target Group:</label>
         <select id="sector"></select>
 
-        <label for="startDate">Başlangıç:</label>
+        <label for="startDate" id="lblStart">Start:</label>
         <input type="date" id="startDate">
-        <label for="endDate">Bitiş:</label>
+        <label for="endDate" id="lblEnd">End:</label>
         <input type="date" id="endDate">
-        <button id="rangeBtn">Aralığı Hesapla</button>
+        <button id="rangeBtn">Calculate Range</button>
     </div>
 
     <div id="rangeResult" style="margin-top: 10px;"></div>
@@ -97,6 +106,28 @@
 <script>
 // Takvim nesnesini daha geniş bir kapsamda tanımlayalım ki her yerden ulaşılabilsin.
 let calendar;
+let currentLang = 'en';
+let translations = {};
+
+async function loadTranslations(lang) {
+    const res = await fetch(`/lang/${lang}.json`);
+    translations = await res.json();
+    currentLang = lang;
+    document.getElementById('lblCountry').textContent = translations.country + ':';
+    document.getElementById('lblView').textContent = translations.view + ':';
+    document.getElementById('optMonth').textContent = translations.month;
+    document.getElementById('optYear').textContent = translations.year;
+    document.getElementById('lblType').textContent = translations.type + ':';
+    document.getElementById('lblLang').textContent = translations.language + ':';
+    document.getElementById('lblTarget').textContent = translations.targetGroup + ':';
+    document.getElementById('lblStart').textContent = translations.start + ':';
+    document.getElementById('lblEnd').textContent = translations.end + ':';
+    document.getElementById('rangeBtn').textContent = translations.calculate;
+    if (calendar) {
+        calendar.setOption('locale', lang);
+    }
+    loadDescriptions();
+}
 
 async function loadCountries() {
     try {
@@ -118,15 +149,33 @@ async function loadCountries() {
 
 async function loadSectorTypes() {
     try {
-        const res = await fetch('/api/sector-types');
-        if (!res.ok) throw new Error('Sektör tipleri yüklenemedi.');
+        const res = await fetch('/api/target-groups');
+        if (!res.ok) throw new Error('Types load error');
         const types = await res.json();
         const select = document.getElementById('sector');
         select.innerHTML = ''; // Önceki seçenekleri temizle
         types.forEach(t => {
             const opt = document.createElement('option');
-            opt.value = t;
-            opt.textContent = t;
+            opt.value = t.code;
+            opt.textContent = t.code;
+            select.appendChild(opt);
+        });
+    } catch (e) {
+        console.error(e);
+    }
+}
+
+async function loadHolidayTypes() {
+    try {
+        const res = await fetch('/api/holiday-types');
+        if (!res.ok) throw new Error('type err');
+        const types = await res.json();
+        const select = document.getElementById('type');
+        select.innerHTML = '';
+        types.forEach(t => {
+            const opt = document.createElement('option');
+            opt.value = t.code;
+            opt.textContent = t.code;
             select.appendChild(opt);
         });
     } catch (e) {
@@ -144,24 +193,46 @@ function initializeCalendar() {
         },
         events: fetchEvents,
         eventClick: showDetails,
-        locale: 'tr'
+        locale: currentLang
     });
     calendar.render();
 }
 
+async function loadDescriptions() {
+    const countryId = document.getElementById('country').value;
+    if (!countryId) {
+        document.getElementById('holidaySummary').innerHTML = '';
+        return;
+    }
+    try {
+        const res = await fetch(`/api/holidays/descriptions?countryId=${countryId}&language=${currentLang}`);
+        if (!res.ok) throw new Error('desc');
+        const list = await res.json();
+        const items = list.map(d => {
+            const dateStr = new Date(d.startDate).toLocaleDateString(currentLang);
+            return `<li>${dateStr} - <strong>${d.name}</strong>: ${d.description}</li>`;
+        }).join('');
+        document.getElementById('holidaySummary').innerHTML = `<ul>${items}</ul>`;
+    } catch (e) {
+        console.error(e);
+    }
+}
+
 function setupEventListeners() {
-    // Ülke veya Sektör filtresi değiştiğinde takvimi yenile
     ['country', 'sector'].forEach(id => {
         document.getElementById(id).addEventListener('change', () => {
-            // Tarayıcı konsolunda bu mesajı görüyorsanız, filtre çalışıyor demektir.
-            console.log(`${id} filtresi değişti. Takvim yenileniyor...`);
             if (calendar) {
                 calendar.refetchEvents();
             }
+            if (id === 'country') loadDescriptions();
         });
     });
 
-    // Görünüm (Aylık/Yıllık) filtresi değiştiğinde takvimin görünümünü değiştir
+    document.getElementById('lang').addEventListener('change', e => {
+        loadTranslations(e.target.value);
+    });
+
+    // Change calendar view when selection changes
     document.getElementById('viewSelect').addEventListener('change', (event) => {
         if (calendar) {
             calendar.changeView(event.target.value);
@@ -178,12 +249,12 @@ async function fetchEvents(fetchInfo, successCallback, failureCallback) {
 
         // Eğer filtrelerden biri boşsa (veri henüz yüklenmediyse) tatil getirme
         if (!countryId || !sector) {
-            successCallback([]); // Boş bir dizi gönder
+            successCallback([]);
             updateSummary([]);
             return;
         }
 
-        const res = await fetch(`/api/holidays/filter-by-sector?countryId=${countryId}&sectorType=${encodeURIComponent(sector)}`);
+        const res = await fetch(`/api/holidays/filter?countryId=${countryId}&targetGroup=${encodeURIComponent(sector)}`);
         if (!res.ok) throw new Error('Tatiller getirilemedi.');
         
         const holidays = await res.json();
@@ -205,11 +276,11 @@ async function fetchEvents(fetchInfo, successCallback, failureCallback) {
 function updateSummary(events) {
     const summary = document.getElementById('holidaySummary');
     if (events.length === 0) {
-        summary.textContent = 'Seçili kriterlere göre tatil bulunamadı.';
+        summary.textContent = translations.noHolidays;
         return;
     }
     const items = events.map(ev => {
-        const dateStr = new Date(ev.start).toLocaleDateString('tr-TR', { day: '2-digit', month: 'long', year: 'numeric' });
+        const dateStr = new Date(ev.start).toLocaleDateString(currentLang, { day: '2-digit', month: 'long', year: 'numeric' });
         return `<li>${dateStr} - ${ev.title}</li>`;
     }).join('');
     summary.innerHTML = `<ul>${items}</ul>`;
@@ -217,13 +288,13 @@ function updateSummary(events) {
 
 function showDetails(info) {
     const h = info.event.extendedProps;
-    const dateStr = new Date(h.holidayDate).toLocaleDateString('tr-TR', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
+    const dateStr = new Date(h.holidayDate).toLocaleDateString(currentLang, { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
     const details = `
         <h3>${h.holidayName}</h3>
-        <p><strong>Türü:</strong> ${h.holidayType}</p>
-        <p><strong>Tarih:</strong> ${dateStr}</p>
-        <p><strong>Süre:</strong> ${h.durationDays} gün</p>
-        <p><strong>Geçerli Sektör:</strong> ${h.appliesToSector}</p>
+        <p><strong>Type:</strong> ${h.holidayType}</p>
+        <p><strong>Date:</strong> ${dateStr}</p>
+        <p><strong>Duration:</strong> ${h.durationDays} days</p>
+        <p><strong>Target:</strong> ${h.appliesToSector}</p>
     `;
     document.getElementById('holidayDetails').innerHTML = details;
 }
@@ -231,16 +302,17 @@ function showDetails(info) {
 async function calculateRange() {
     const countryId = document.getElementById('country').value;
     const sector = document.getElementById('sector').value;
+    const type = document.getElementById('type').value;
     const start = document.getElementById('startDate').value;
     const end = document.getElementById('endDate').value;
 
-    if (!countryId || !sector || !start || !end) {
-        document.getElementById('rangeResult').textContent = 'Lütfen tüm alanları doldurun.';
+    if (!countryId || !sector || !type || !start || !end) {
+        document.getElementById('rangeResult').textContent = 'Please fill all fields.';
         return;
     }
 
     try {
-        const res = await fetch(`/api/holidays/range?countryId=${countryId}&sectorType=${encodeURIComponent(sector)}&start=${start}&end=${end}`);
+        const res = await fetch(`/api/holidays/range-filtered?countryId=${countryId}&holidayType=${encodeURIComponent(type)}&targetGroup=${encodeURIComponent(sector)}&start=${start}&end=${end}`);
         if (!res.ok) throw new Error('Tatiller getirilemedi.');
         const holidays = await res.json();
 
@@ -258,7 +330,7 @@ async function calculateRange() {
         }
 
         document.getElementById('rangeResult').textContent =
-            `Toplam ${holidays.length} tatil günü, ${workDays} iş günü.`;
+            `${holidays.length} holidays, ${workDays} work days.`;
     } catch (e) {
         console.error(e);
         document.getElementById('rangeResult').textContent = 'Hata oluştu.';
@@ -266,16 +338,11 @@ async function calculateRange() {
 }
 
 async function init() {
-    // 1. Önce takvimi ekrana çiz.
+    await loadTranslations(currentLang);
     initializeCalendar();
-    
-    // 2. Sonra filtreler için gerekli verileri (ülke, sektör) yükle.
-    await Promise.all([loadCountries(), loadSectorTypes()]);
-    
-    // 3. Veriler yüklendikten sonra, takvimin ilk verilerini getirmesi için onu tetikle.
-    calendar.refetchEvents();
 
-    // 4. Son olarak, filtrelerin değişikliklerini dinleyecek olan kodları çalıştır.
+    await Promise.all([loadCountries(), loadSectorTypes(), loadHolidayTypes()]);
+    calendar.refetchEvents();
     setupEventListeners();
 }
 

--- a/src/main/resources/static/lang/en.json
+++ b/src/main/resources/static/lang/en.json
@@ -1,0 +1,13 @@
+{
+  "country": "Country",
+  "view": "View",
+  "month": "Monthly",
+  "year": "Yearly",
+  "type": "Type",
+  "targetGroup": "Target Group",
+  "start": "Start",
+  "end": "End",
+  "calculate": "Calculate Range",
+  "noHolidays": "No holidays found for selection.",
+  "language": "Language"
+}

--- a/src/main/resources/static/lang/fr.json
+++ b/src/main/resources/static/lang/fr.json
@@ -1,0 +1,13 @@
+{
+  "country": "Pays",
+  "view": "Vue",
+  "month": "Mensuel",
+  "year": "Annuel",
+  "type": "Type",
+  "targetGroup": "Groupe cible",
+  "start": "Début",
+  "end": "Fin",
+  "calculate": "Calculer",
+  "noHolidays": "Aucun jour férié trouvé.",
+  "language": "Langue"
+}


### PR DESCRIPTION
## Summary
- add DTO and repository method to fetch holiday descriptions by language
- enable filtering holidays by type and target group
- expose new controllers for holiday types and target groups
- add English and French translations
- update frontend to support language toggle, holiday type filter and translation loading

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686917032a10832eb0e211d359d9d119