### PR TITLE
Fix holiday calendar data endpoint

### DIFF
--- a/src/main/java/com/tatilsorgulama/api/controller/HolidayController.java
+++ b/src/main/java/com/tatilsorgulama/api/controller/HolidayController.java
@@ -3,6 +3,7 @@ package com.tatilsorgulama.api.controller;
 import com.tatilsorgulama.api.entity.Holiday;
 import com.tatilsorgulama.api.repository.HolidayRepository;
 import com.tatilsorgulama.api.dto.HolidayDescDto;
+import com.tatilsorgulama.api.dto.HolidayEventDto;
 import com.tatilsorgulama.api.repository.HolidayDescriptionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -43,11 +44,12 @@ public class HolidayController {
 
     // Filters holidays by country and target group code
     @GetMapping("/filter")
-    public ResponseEntity<List<Holiday>> filterHolidays(
+    public ResponseEntity<List<HolidayEventDto>> filterHolidays(
             @RequestParam Integer countryId,
-            @RequestParam String targetGroup) {
-        List<Holiday> holidays = holidayRepository
-                .findByCountryAndTargetGroup(countryId, targetGroup);
+            @RequestParam String targetGroup,
+            @RequestParam(defaultValue = "en") String lang) {
+        List<HolidayEventDto> holidays = holidayRepository
+                .findEvents(countryId, targetGroup, lang);
         return ResponseEntity.ok(holidays);
     }
     

--- a/src/main/java/com/tatilsorgulama/api/dto/HolidayEventDto.java
+++ b/src/main/java/com/tatilsorgulama/api/dto/HolidayEventDto.java
@@ -1,0 +1,22 @@
+package com.tatilsorgulama.api.dto;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+public record HolidayEventDto(String holidayName,
+                              String holidayType,
+                              LocalDate holidayDate,
+                              long durationDays,
+                              String appliesToSector) {
+    public HolidayEventDto(String holidayName,
+                           String holidayType,
+                           LocalDate startDate,
+                           LocalDate endDate,
+                           String appliesToSector) {
+        this(holidayName,
+             holidayType,
+             startDate,
+             ChronoUnit.DAYS.between(startDate, endDate) + 1,
+             appliesToSector);
+    }
+}

--- a/src/main/java/com/tatilsorgulama/api/repository/HolidayRepository.java
+++ b/src/main/java/com/tatilsorgulama/api/repository/HolidayRepository.java
@@ -1,6 +1,7 @@
 package com.tatilsorgulama.api.repository;
 
 import com.tatilsorgulama.api.entity.Holiday;
+import com.tatilsorgulama.api.dto.HolidayEventDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -17,6 +18,18 @@ public interface HolidayRepository extends JpaRepository<Holiday, Integer> {
 
     @Query("select distinct h from Holiday h join h.targetGroups tg where h.country.id = :countryId and tg.code = :groupCode")
     List<Holiday> findByCountryAndTargetGroup(Integer countryId, String groupCode);
+
+    @Query("select new com.tatilsorgulama.api.dto.HolidayEventDto(" +
+            "hd.name, ht.code, h.startDate, h.endDate, tg.code) " +
+            "from Holiday h " +
+            "join h.targetGroups tg " +
+            "join h.holidayType ht " +
+            "join h.descriptions hd " +
+            "where h.country.id = :countryId " +
+            "and tg.code = :groupCode " +
+            "and hd.languageCode = :lang " +
+            "order by h.startDate")
+    List<HolidayEventDto> findEvents(Integer countryId, String groupCode, String lang);
 
     @Query("select distinct h from Holiday h join h.targetGroups tg where h.country.id = :countryId and tg.code = :groupCode and h.startDate between :startDate and :endDate")
     List<Holiday> findByCountryTargetGroupAndDateBetween(Integer countryId,

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -254,7 +254,7 @@ async function fetchEvents(fetchInfo, successCallback, failureCallback) {
             return;
         }
 
-        const res = await fetch(`/api/holidays/filter?countryId=${countryId}&targetGroup=${encodeURIComponent(sector)}`);
+        const res = await fetch(`/api/holidays/filter?countryId=${countryId}&targetGroup=${encodeURIComponent(sector)}&lang=${currentLang}`);
         if (!res.ok) throw new Error('Tatiller getirilemedi.');
         
         const holidays = await res.json();


### PR DESCRIPTION
## Summary
- add `HolidayEventDto` for calendar events
- query translated event details in `HolidayRepository`
- update `HolidayController` to return `HolidayEventDto`
- send current language in calendar fetch

## Testing
- `./mvnw -q test` *(fails: could not download maven)*

------
https://chatgpt.com/codex/tasks/task_e_68694c66c54c832eb126bb2abdb7e7ca